### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
+

--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 
 
+

--- a/README.md
+++ b/README.md
@@ -15,3 +15,4 @@ For more information see the [Code of Conduct FAQ](https://opensource.microsoft.
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
 
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/ravigadhia0765/d1f4d3d4-0550-4061-be43-937bf52c9bad/f5b1b9b4-818a-4b0e-b176-12317e81ff23/_apis/work/boardbadge/878309b7-68ff-4f1d-bc19-486b427d323c)](https://dev.azure.com/ravigadhia0765/d1f4d3d4-0550-4061-be43-937bf52c9bad/_boards/board/t/f5b1b9b4-818a-4b0e-b176-12317e81ff23/Microsoft.RequirementCategory)
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -14,4 +14,3 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
-


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/ravigadhia0765/d1f4d3d4-0550-4061-be43-937bf52c9bad/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.